### PR TITLE
add card reader proof of concept

### DIFF
--- a/client/src/common/PrettyModal.tsx
+++ b/client/src/common/PrettyModal.tsx
@@ -1,0 +1,34 @@
+import React, { ReactNode } from "react";
+import { Card, Modal } from "@mui/material";
+
+interface PrettyModalProps {
+  open: boolean;
+  onClose: () => void;
+  width?: number;
+  children: ReactNode;
+}
+
+export default function PrettyModal({
+  width = 400,
+  open,
+  onClose,
+  children,
+}: PrettyModalProps) {
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Card
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width,
+          boxShadow: 24,
+          p: 4,
+        }}
+      >
+        {children}
+      </Card>
+    </Modal>
+  );
+}

--- a/client/src/left_nav/CardReaderAlert.tsx
+++ b/client/src/left_nav/CardReaderAlert.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import CreditCardIcon from "@mui/icons-material/CreditCard";
+import { Typography } from "@mui/material";
+import { Alert } from "@mui/lab";
+import PrettyModal from "../common/PrettyModal";
+
+const SWIPE_START_CHAR = ";";
+const SWIPE_END_CHAR = "?";
+
+interface CardReaderAlertProps {}
+
+let readingSwipe = false;
+let swipeBuffer: string[] = [];
+
+export default function CardReaderAlert({}: CardReaderAlertProps) {
+  const [showModal, setShowModal] = useState(false);
+  const [uid, setUid] = useState("");
+
+  useEffect(() => {
+    document.addEventListener("keydown", ({ key }) => {
+      if (readingSwipe) {
+        swipeBuffer.push(key);
+      }
+
+      if (key === SWIPE_START_CHAR) {
+        readingSwipe = true;
+        swipeBuffer = [];
+      }
+
+      if (key === SWIPE_END_CHAR) {
+        readingSwipe = false;
+
+        const uidString = swipeBuffer.slice(0, 9).join("");
+        setUid(uidString);
+
+        setShowModal(true);
+      }
+    });
+  }, []);
+
+  return (
+    <>
+      <Alert severity="info" icon={<CreditCardIcon />} sx={{ borderRadius: 0 }}>
+        <Typography variant="body1" sx={{ lineHeight: 1.2, mt: "2px" }}>
+          Listening for card swipes...
+        </Typography>
+      </Alert>
+
+      <PrettyModal open={showModal} onClose={() => setShowModal(false)}>
+        {uid}
+      </PrettyModal>
+    </>
+  );
+}

--- a/client/src/left_nav/LeftNav.tsx
+++ b/client/src/left_nav/LeftNav.tsx
@@ -18,6 +18,7 @@ import LogoSvg from "../assets/logo.svg";
 import styled from "styled-components";
 import MonitorIcon from "@mui/icons-material/Monitor";
 import MonitorAlert from "./MonitorAlert";
+import CardReaderAlert from "./CardReaderAlert";
 
 const StyledLogo = styled.img`
   margin: 20px 12px 12px 12px;
@@ -51,9 +52,13 @@ export default function LeftNav() {
         </Typography>
       </Stack>
 
-      <MonitorAlert />
+      <Stack spacing={1} my={2}>
+        <MonitorAlert />
 
-      {false && <HoldAlert />}
+        <CardReaderAlert />
+
+        {false && <HoldAlert />}
+      </Stack>
 
       <List component="nav">
         <Divider textAlign="left">MAKER</Divider>

--- a/client/src/left_nav/MonitorAlert.tsx
+++ b/client/src/left_nav/MonitorAlert.tsx
@@ -7,20 +7,16 @@ interface MonitoringBoxProps {}
 
 export default function MonitorAlert({}: MonitoringBoxProps) {
   return (
-    <Alert
-      severity="info"
-      icon={<MonitorIcon />}
-      sx={{ mb: 2, borderRadius: 0 }}
-    >
+    <Alert severity="info" icon={<MonitorIcon />} sx={{ borderRadius: 0 }}>
       <Stack>
-        <Typography variant="body1">
+        <Typography variant="body1" sx={{ lineHeight: 1.2, mt: "2px" }}>
           You are monitoring the{" "}
           <Link href="/admin/monitor/sample-room" sx={{ fontWeight: 500 }}>
             woodshop
           </Link>
         </Typography>
 
-        <Stack direction="row" alignItems="center" sx={{ mt: 1 }}>
+        <Stack direction="row" alignItems="center" sx={{ mt: 2 }}>
           <Typography variant="body1" sx={{ fontWeight: 500, flexGrow: 1 }}>
             23:45
           </Typography>


### PR DESCRIPTION
- The card reader types `;` before typing the ID number
- I put a global `keydown` listener, which waits until `;` is typed, then writes down the following numbers
- Then a modal pops up showing the ID number from the card
- Then it sends it to my personal database so I can commit financial fraud later