### PR TITLE
fix the issue with graphql playground not working locally

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,5 +1,8 @@
 import express from "express";
 import { ApolloServer } from "apollo-server-express";
+import {
+  ApolloServerPluginLandingPageGraphQLPlayground
+} from "apollo-server-core";
 import { createServer } from "http";
 import compression from "compression";
 import cors from "cors";
@@ -7,25 +10,25 @@ import helmet from "helmet";
 import { schema } from "./schema";
 import dotenv from 'dotenv'
 
-dotenv.config({path:__dirname+'/./../.env'})
+dotenv.config({ path: __dirname + '/./../.env' })
 
 const PORT = process.env.PORT || 3000;
 const app = express();
-const corstOpts = cors({ origin: true });
+const corstOpts = cors();
 
 app.use(corstOpts);
-app.use(helmet());
 app.use(compression());
 
 const server = new ApolloServer({
   schema,
-  introspection: true,
-  debug: process.env.NODE_DEV === 'development',
+  plugins: [
+    ApolloServerPluginLandingPageGraphQLPlayground(),
+  ],
 });
 
-(async function startServer () {
-    await server.start();
-    server.applyMiddleware({ app, path: "/graphql" });
+(async function startServer() {
+  await server.start();
+  server.applyMiddleware({ app, path: "/graphql" });
 })();
 
 const httpServer = createServer(app);


### PR DESCRIPTION
Helmet was messing with the content security policy. Adding the plugin makes the playground load when visiting localhost:port/graphql