### PR TITLE
Extract route definitions to separate component

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,20 +1,7 @@
 import * as React from "react";
-import LeftNav from "./left_nav/LeftNav";
-import { BrowserRouter, Route, Switch } from "react-router-dom";
-import Page from "./pages/Page";
-import { Box, createTheme, ThemeProvider } from "@mui/material";
-import EquipmentPage from "./pages/both/EquipmentPage";
-import CreateReservationPage from "./pages/maker/create_reservation/CreateReservationPage";
-import TrainingModulesPage from "./pages/admin/training_modules/TrainingModulesPage";
-import EditModulePage from "./pages/admin/edit_module/EditModulePage";
-import EditEquipmentPage from "./pages/admin/edit_equipment/EditEquipmentPage";
-import SelectRoomPage from "./pages/admin/monitor/SelectRoomPage";
-import MonitorRoomPage from "./pages/admin/monitor/MonitorRoomPage";
-import StorefrontPage from "./pages/admin/storefront/StorefrontPage";
-import StorefrontPreviewPage from "./pages/admin/storefront_preview/StorefrontPreviewPage";
-import InventoryPage from "./pages/admin/inventory/InventoryPage";
-import EditMaterialPage from "./pages/admin/edit_material/EditMaterialPage";
+import { createTheme, ThemeProvider } from "@mui/material";
 import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
+import Routes from "./Routes";
 
 const apolloClient = new ApolloClient({
   uri: process.env.REACT_APP_GRAPHQL_URL ?? "http://localhost:3000/graphql",
@@ -27,83 +14,7 @@ export default function App() {
   return (
     <ApolloProvider client={apolloClient}>
       <ThemeProvider theme={theme}>
-        <BrowserRouter>
-          <Switch>
-            <Route path="/admin/storefront/preview">
-              <StorefrontPreviewPage />
-            </Route>
-
-            <Box sx={{ display: "flex" }}>
-              <LeftNav />
-
-              <Switch>
-                <Route path="/create-reservation">
-                  <CreateReservationPage />
-                </Route>
-
-                <Route path="/quiz-builder">
-                  <EditModulePage />
-                </Route>
-
-                <Route path="/maker/equipment">
-                  <EquipmentPage isAdmin={false} />
-                </Route>
-
-                <Route path="/maker/training">
-                  <Page title="Training" />
-                </Route>
-
-                <Route path="/maker/materials">
-                  <Page title="Materials" />
-                </Route>
-
-                <Route path="/admin/edit-equipment">
-                  <EditEquipmentPage />
-                </Route>
-
-                <Route path="/admin/equipment">
-                  <EquipmentPage isAdmin={true} />
-                </Route>
-
-                <Route path="/admin/training">
-                  <TrainingModulesPage />
-                </Route>
-
-                <Route path="/admin/inventory/:id">
-                  <EditMaterialPage />
-                </Route>
-
-                <Route path="/admin/inventory">
-                  <InventoryPage />
-                </Route>
-
-                <Route path="/admin/reservations">
-                  <Page title="Reservations" />
-                </Route>
-
-                <Route path="/admin/monitor/select-room">
-                  <SelectRoomPage />
-                </Route>
-
-                <Route path="/admin/monitor/sample-room">
-                  <MonitorRoomPage />
-                </Route>
-
-                <Route path="/admin/storefront">
-                  <StorefrontPage />
-                </Route>
-
-                <Route path="/admin/people">
-                  <Page title="People" />
-                </Route>
-
-                <Route path="/admin/audit">
-                  <Page title="Audit Logs" />
-                </Route>
-              </Switch>
-            </Box>
-          </Switch>
-        </BrowserRouter>
+        <Routes />
       </ThemeProvider>
     </ApolloProvider>
   );

--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { BrowserRouter, Route, Switch } from "react-router-dom";
+import StorefrontPreviewPage from "./pages/admin/storefront_preview/StorefrontPreviewPage";
+import { Box } from "@mui/material";
+import LeftNav from "./left_nav/LeftNav";
+import CreateReservationPage from "./pages/maker/create_reservation/CreateReservationPage";
+import EditModulePage from "./pages/admin/edit_module/EditModulePage";
+import EquipmentPage from "./pages/both/EquipmentPage";
+import Page from "./pages/Page";
+import EditEquipmentPage from "./pages/admin/edit_equipment/EditEquipmentPage";
+import TrainingModulesPage from "./pages/admin/training_modules/TrainingModulesPage";
+import EditMaterialPage from "./pages/admin/edit_material/EditMaterialPage";
+import InventoryPage from "./pages/admin/inventory/InventoryPage";
+import SelectRoomPage from "./pages/admin/monitor/SelectRoomPage";
+import MonitorRoomPage from "./pages/admin/monitor/MonitorRoomPage";
+import StorefrontPage from "./pages/admin/storefront/StorefrontPage";
+
+// This is where we map the browser's URL to a
+// React component with the help of React Router.
+
+export default function Routes() {
+  return (
+    <BrowserRouter>
+      <Switch>
+        <Route path="/admin/storefront/preview">
+          <StorefrontPreviewPage />
+        </Route>
+
+        <Box sx={{ display: "flex" }}>
+          <LeftNav />
+
+          <Switch>
+            <Route path="/create-reservation">
+              <CreateReservationPage />
+            </Route>
+
+            <Route path="/quiz-builder">
+              <EditModulePage />
+            </Route>
+
+            <Route path="/maker/equipment">
+              <EquipmentPage isAdmin={false} />
+            </Route>
+
+            <Route path="/maker/training">
+              <Page title="Training" />
+            </Route>
+
+            <Route path="/maker/materials">
+              <Page title="Materials" />
+            </Route>
+
+            <Route path="/admin/edit-equipment">
+              <EditEquipmentPage />
+            </Route>
+
+            <Route path="/admin/equipment">
+              <EquipmentPage isAdmin={true} />
+            </Route>
+
+            <Route path="/admin/training">
+              <TrainingModulesPage />
+            </Route>
+
+            <Route path="/admin/inventory/:id">
+              <EditMaterialPage />
+            </Route>
+
+            <Route path="/admin/inventory">
+              <InventoryPage />
+            </Route>
+
+            <Route path="/admin/reservations">
+              <Page title="Reservations" />
+            </Route>
+
+            <Route path="/admin/monitor/select-room">
+              <SelectRoomPage />
+            </Route>
+
+            <Route path="/admin/monitor/sample-room">
+              <MonitorRoomPage />
+            </Route>
+
+            <Route path="/admin/storefront">
+              <StorefrontPage />
+            </Route>
+
+            <Route path="/admin/people">
+              <Page title="People" />
+            </Route>
+
+            <Route path="/admin/audit">
+              <Page title="Audit Logs" />
+            </Route>
+          </Switch>
+        </Box>
+      </Switch>
+    </BrowserRouter>
+  );
+}


### PR DESCRIPTION
Our frontend entry point, `App.tsx`, was getting a little cluttered with all the React Router route definitions. I moved these to their own component, which tidies things up nicely.