### PR TITLE
prototype user management page

### DIFF
--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -15,6 +15,7 @@ import SelectRoomPage from "./pages/admin/monitor/SelectRoomPage";
 import MonitorRoomPage from "./pages/admin/monitor/MonitorRoomPage";
 import StorefrontPage from "./pages/admin/storefront/StorefrontPage";
 import TrainingPage from "./pages/maker/training/TrainingPage";
+import UsersPage from "./pages/admin/users/UsersPage";
 
 // This is where we map the browser's URL to a
 // React component with the help of React Router.
@@ -88,7 +89,7 @@ export default function Routes() {
             </Route>
 
             <Route path="/admin/people">
-              <Page title="People" />
+              <UsersPage />
             </Route>
 
             <Route path="/admin/audit">

--- a/client/src/pages/admin/users/UserCard.tsx
+++ b/client/src/pages/admin/users/UserCard.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import {
+  Avatar,
+  Card,
+  CardActionArea,
+  Chip,
+  Stack,
+  Typography,
+} from "@mui/material";
+import User from "../../../types/User";
+
+interface UserCardProps {
+  user: User;
+}
+
+export default function UserCard({ user }: UserCardProps) {
+  return (
+    <Card elevation={2} sx={{ mr: 2, mb: 2 }}>
+      <CardActionArea sx={{ p: 2, height: "100%" }}>
+        <Stack alignItems="center" spacing={1.5} height="100%">
+          <Avatar alt="" src={user.image} sx={{ width: 80, height: 80 }} />
+          <Typography
+            variant="body1"
+            fontWeight={500}
+            width={120}
+            textAlign="center"
+            lineHeight={1.25}
+            flex={1}
+          >
+            {user.name}
+          </Typography>
+          {user.role !== "Maker" && (
+            <Chip
+              label={user.role}
+              variant="outlined"
+              size="small"
+              color={user.role === "Admin" ? "primary" : "secondary"}
+            />
+          )}
+        </Stack>
+      </CardActionArea>
+    </Card>
+  );
+}

--- a/client/src/pages/admin/users/UsersPage.tsx
+++ b/client/src/pages/admin/users/UsersPage.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Page from "../../Page";
+import SearchBar from "../../../common/SearchBar";
+import generateUsers from "../../../test_data/Users";
+import { Stack } from "@mui/material";
+import UserCard from "./UserCard";
+
+const testUsers = generateUsers(3, 9, 50);
+
+interface UsersPageProps {}
+
+export default function UsersPage({}: UsersPageProps) {
+  return (
+    <Page title="People">
+      <SearchBar placeholder="Search people" sx={{ mb: 2 }} />
+      <Stack direction="row" flexWrap="wrap">
+        {testUsers.map((u) => (
+          <UserCard user={u} key={u.id} />
+        ))}
+      </Stack>
+    </Page>
+  );
+}

--- a/client/src/test_data/Users.ts
+++ b/client/src/test_data/Users.ts
@@ -1,0 +1,73 @@
+import { v4 as uuidv4 } from "uuid";
+
+const firstNames = [
+  "Bob",
+  "Susan",
+  "Karen",
+  "Kyle",
+  "Robert",
+  "Dave",
+  "James",
+  "Mary",
+  "Patricia",
+];
+
+const lastNames = [
+  "Smith",
+  "Goodman",
+  "Gates",
+  "Musk",
+  "Matthews",
+  "Johnson",
+  "Williams",
+  "Brown",
+  "Garcia",
+];
+
+// don't tell adobe
+const images = [
+  "https://t4.ftcdn.net/jpg/03/83/25/83/240_F_383258331_D8imaEMl8Q3lf7EKU2Pi78Cn0R7KkW9o.jpg",
+  "https://t3.ftcdn.net/jpg/02/99/04/20/240_F_299042079_vGBD7wIlSeNl7vOevWHiL93G4koMM967.jpg",
+  "https://t3.ftcdn.net/jpg/03/02/88/46/240_F_302884605_actpipOdPOQHDTnFtp4zg4RtlWzhOASp.jpg",
+  "https://t4.ftcdn.net/jpg/01/51/99/39/240_F_151993994_mmAYzngmSbNRr6Fxma67Od3WHrSkfG5I.jpg",
+  "https://t3.ftcdn.net/jpg/02/43/76/54/240_F_243765470_a0hN5zuTKIonTbRGldi8KajuvhSiWvDx.jpg",
+  "https://t3.ftcdn.net/jpg/01/92/16/04/240_F_192160468_2ev2JYmocXi7pxbBiPsfNEVwDqmTTLYL.jpg",
+  "https://t4.ftcdn.net/jpg/03/13/37/31/240_F_313373132_b9Az7XaGLRvSLHXlINXBIGPMIOLok8ZB.jpg",
+  "https://t3.ftcdn.net/jpg/03/49/48/42/240_F_349484220_ztenUZ8pQZ1IC5wsBTWaUZTnMIKZ9wJz.jpg",
+  "https://t4.ftcdn.net/jpg/03/61/34/27/240_F_361342769_X26dTcofZpukhMGYWFcn1wJNABEFtNLH.jpg",
+];
+
+function getRandomListElement(list: any[]) {
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function generateUser(role: string) {
+  const image = getRandomListElement(images);
+  const firstName = getRandomListElement(firstNames);
+  const lastName = getRandomListElement(lastNames);
+  const name = `${firstName} ${lastName}`;
+
+  return { id: uuidv4(), name, image, role };
+}
+
+export default function generateUsers(
+  adminCount: number,
+  labbieCount: number,
+  makerCount: number
+) {
+  const users = [];
+
+  for (let i = 0; i < adminCount; i++) {
+    users.push(generateUser("Admin"));
+  }
+
+  for (let i = 0; i < labbieCount; i++) {
+    users.push(generateUser("Labbie"));
+  }
+
+  for (let i = 0; i < makerCount; i++) {
+    users.push(generateUser("Maker"));
+  }
+
+  return users;
+}

--- a/client/src/types/User.ts
+++ b/client/src/types/User.ts
@@ -1,0 +1,6 @@
+export default interface User {
+  id: string;
+  name: string;
+  image: string;
+  role: string;
+}


### PR DESCRIPTION
Prototyped user management page. Clicking on a user card will (in theory) bring you to the management page for that specific user, where you can view more detailed information and perform management actions.

![image](https://user-images.githubusercontent.com/20482179/150887020-5262fb67-774f-4d68-bf07-a7816c95d681.png)
