### PR TITLE
Create holds schema

### DIFF
--- a/server/src/db/migrations/20210923214317_initial_users.ts
+++ b/server/src/db/migrations/20210923214317_initial_users.ts
@@ -10,11 +10,11 @@ export async function up(knex: Knex): Promise<void> {
             t.string('first_name', 100);
             t.string('last_name', 100);
             t.text('email').unique();
-            t.string('type', 8); // student, faculty, employee
-            t.string('privilege_level', 6); // maker, labbie, admin
+            t.enu('type', ['student', 'faculty', 'employee']);
+            t.enu('privilege_level', ['maker', 'labbie', 'admin']);
             t.date('registration_date').defaultTo(knex.fn.now());
             t.decimal('balance');
-            t.boolean('hold').defaultTo(false);
+            t.integer('holds');
             t.integer('year');
             t.text('college');
             t.text('major');

--- a/server/src/db/migrations/20211102194503_machines_table.ts
+++ b/server/src/db/migrations/20211102194503_machines_table.ts
@@ -20,7 +20,7 @@ export async function up(knex: Knex): Promise<void> {
           t.string('name', 50);
           t.integer('machine_family').references('id').inTable('MachineFamilies');
           t.string('room', 5);
-          t.timestamp('added_at').defaultTo(knex.fn.now());
+          t.timestamp('added_on').defaultTo(knex.fn.now());
           t.boolean('in_use').defaultTo(false);
         });
       }
@@ -29,9 +29,9 @@ export async function up(knex: Knex): Promise<void> {
       if (!exists) {
         return knex.schema.createTable('Reservations', function (t) {
           t.increments('id');
-          t.integer('student_id').references('id').inTable('Students');
+          t.integer('student_id').references('id').inTable('Users');
           t.integer('machine_id').references('id').inTable('Machines');
-          t.timestamp('created_at').defaultTo(knex.fn.now());
+          t.timestamp('created_on').defaultTo(knex.fn.now());
           t.time('start_time');
           t.time('end_time');
         });

--- a/server/src/db/migrations/20220126063347_holds_table.ts
+++ b/server/src/db/migrations/20220126063347_holds_table.ts
@@ -1,0 +1,26 @@
+import { Knex } from "knex";
+
+
+export async function up(knex: Knex): Promise<void> {
+    return knex.schema.hasTable('Holds').then(function(exists) {
+        if (!exists) {
+            return knex.schema.createTable('Holds', function(t) {
+                t.increments('id');
+                t.enu('type', ['incomplete_training', 'safety_violation', 'financial']);
+                t.text('description');
+                t.timestamp('created_on').defaultTo(knex.fn.now());
+                t.timestamp('removed_on');
+                t.integer('user_id').references('id').inTable('Users');
+              });
+        }
+    });
+}
+
+
+export async function down(knex: Knex): Promise<void> {
+    return knex.schema.hasTable('Holds').then(function(exists) {
+        if (exists) {
+          return knex.schema.dropTable('Holds');
+        }
+      });
+}

--- a/server/src/schemas/holdsSchema.ts
+++ b/server/src/schemas/holdsSchema.ts
@@ -1,0 +1,37 @@
+import { gql } from "apollo-server-express";
+
+export const MachinesTypeDefs = gql`
+
+  enum HoldType {
+    INCOMPLETE_TRAINING
+    SAFETY_VIOLATION
+    BALANCE_DUE
+  }
+
+  type Hold {
+    id: ID!
+    type: HoldType!
+    description: String
+    createdOn: Date
+    removedOn: Date
+    userId: User!
+  }
+
+  input HoldInput {
+    id: Int!
+    type: HoldType!
+    description: String
+    createdOn: Date
+    removedOn: Date
+    userId: Int!
+  }
+
+  type Query {
+      holds: [Hold]
+  }
+
+  type Mutation {
+    placeHold(hold: HoldInput): Hold
+    removeHold(holdId: ID!): Hold
+  }
+`;

--- a/server/src/schemas/machinesSchema.ts
+++ b/server/src/schemas/machinesSchema.ts
@@ -6,7 +6,7 @@ export const MachinesTypeDefs = gql`
     machineFamily: MachineFamily!
     name: String!
     room: String!
-    addedAt: Date
+    addedAt: DateTime
     inUse: Boolean!
   }
 
@@ -22,7 +22,7 @@ export const MachinesTypeDefs = gql`
     userId: User!
     supervisorId: User!
     machineId: Machine!
-    createdAt: Date
+    createdAt: DateTime
     startTime: DateTime!
     endTime: DateTime!
   }
@@ -31,7 +31,7 @@ export const MachinesTypeDefs = gql`
     machineFamily: Int!
     name: String!
     room: String!
-    addedAt: Date
+    addedAt: DateTime
     inUse: Boolean!
   }
 
@@ -45,7 +45,7 @@ export const MachinesTypeDefs = gql`
     userId: Int!
     supervisorId: Int!
     machineId: Int!
-    createdAt: Date
+    createdAt: DateTime
     startTime: DateTime!
     endTime: DateTime!
   }


### PR DESCRIPTION
Also, changed type of some `Date` fields in the machines schema to `DateTime` because the corresponding fields in the migration are `timestamp` fields. A GraphQL `DateTime` should be equivalent to a PostgreSQL `timestamp`. 