### PR TITLE
Create holds schema

### DIFF
--- a/server/src/schemas/holdsSchema.ts
+++ b/server/src/schemas/holdsSchema.ts
@@ -12,6 +12,7 @@ export const HoldsTypeDefs = gql`
     id: ID!
     type: HoldType!
     description: String
+    createdBy: User!
     createdAt: DateTime
     removedAt: DateTime
     userId: User!
@@ -21,6 +22,7 @@ export const HoldsTypeDefs = gql`
     id: Int!
     type: HoldType!
     description: String
+    createdBy: Int!
     createdAt: DateTime
     removedAt: DateTime
     userId: Int!

--- a/server/src/schemas/holdsSchema.ts
+++ b/server/src/schemas/holdsSchema.ts
@@ -1,0 +1,37 @@
+import { gql } from "apollo-server-express";
+
+export const HoldsTypeDefs = gql`
+
+  enum HoldType {
+    INCOMPLETE_TRAINING
+    SAFETY_VIOLATION
+    BALANCE_DUE
+  }
+
+  type Hold {
+    id: ID!
+    type: HoldType!
+    description: String
+    createdOn: Date
+    removedOn: Date
+    userId: User!
+  }
+
+  input HoldInput {
+    id: Int!
+    type: HoldType!
+    description: String
+    createdOn: Date
+    removedOn: Date
+    userId: Int!
+  }
+
+  type Query {
+      holds: [Hold]
+  }
+
+  type Mutation {
+    placeHold(hold: HoldInput): Hold
+    removeHold(holdId: ID!): Hold
+  }
+`;

--- a/server/src/schemas/holdsSchema.ts
+++ b/server/src/schemas/holdsSchema.ts
@@ -12,8 +12,8 @@ export const HoldsTypeDefs = gql`
     id: ID!
     type: HoldType!
     description: String
-    createdOn: Date
-    removedOn: Date
+    createdAt: DateTime
+    removedAt: DateTime
     userId: User!
   }
 
@@ -21,8 +21,8 @@ export const HoldsTypeDefs = gql`
     id: Int!
     type: HoldType!
     description: String
-    createdOn: Date
-    removedOn: Date
+    createdAt: DateTime
+    removedAt: DateTime
     userId: Int!
   }
 

--- a/server/src/schemas/machinesSchema.ts
+++ b/server/src/schemas/machinesSchema.ts
@@ -6,7 +6,7 @@ export const MachinesTypeDefs = gql`
     machineFamily: MachineFamily!
     name: String!
     room: String!
-    addedAt: Date
+    addedAt: DateTime
     inUse: Boolean!
   }
 
@@ -22,7 +22,7 @@ export const MachinesTypeDefs = gql`
     userId: User!
     supervisorId: User!
     machineId: Machine!
-    createdAt: Date
+    createdAt: DateTime
     startTime: DateTime!
     endTime: DateTime!
   }
@@ -31,7 +31,7 @@ export const MachinesTypeDefs = gql`
     machineFamily: Int!
     name: String!
     room: String!
-    addedAt: Date
+    addedAt: DateTime
     inUse: Boolean!
   }
 
@@ -45,7 +45,7 @@ export const MachinesTypeDefs = gql`
     userId: Int!
     supervisorId: Int!
     machineId: Int!
-    createdAt: Date
+    createdAt: DateTime
     startTime: DateTime!
     endTime: DateTime!
   }


### PR DESCRIPTION
Also, changed type of some `Date` fields in the machines schema to `DateTime` because the corresponding fields in the migration are `timestamp` fields. A GraphQL `DateTime` should be equivalent to a PostgreSQL `timestamp`. 