### PR TITLE
Set default React port to 3001

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "tsc": "./node_modules/.bin/tsc",
-    "start": "react-app-rewired start",
+    "start": "PORT=3001 react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-app-rewired eject"


### PR DESCRIPTION
If you're running both the backend and frontend at the same time, you'll get a warning that port 3000 is already in use by whichever half you started first.

Setting frontend to run on port 3001 to avoid the issue in the first place.