### PR TITLE
Holds implementation

### DIFF
--- a/client/src/common/CurrentUserProvider.tsx
+++ b/client/src/common/CurrentUserProvider.tsx
@@ -31,7 +31,7 @@ export interface CurrentUser {
   email: string;
   privilege: Privilege;
   setupComplete: boolean;
-  hasHold: boolean;
+  hasHolds: boolean;
 }
 
 const CurrentUserContext = createContext<CurrentUser | undefined>(undefined);
@@ -39,13 +39,13 @@ const CurrentUserContext = createContext<CurrentUser | undefined>(undefined);
 function mapUser(data: any): CurrentUser | undefined {
   if (!data?.currentUser) return undefined;
 
-  const hasHold = data.currentUser.holds.some(
+  const hasHolds = data.currentUser.holds.some(
     (hold: { removeDate: string }) => !hold.removeDate
   );
 
   return {
     ...data.currentUser,
-    hasHold,
+    hasHolds,
   };
 }
 

--- a/client/src/common/PrettyModal.tsx
+++ b/client/src/common/PrettyModal.tsx
@@ -24,7 +24,7 @@ export default function PrettyModal({
           transform: "translate(-50%, -50%)",
           width,
           boxShadow: 24,
-          maxHeight: "calc(100vh - 64px)",
+          maxHeight: "calc(100vh - 160px)",
           overflowY: "auto",
           p: 4,
         }}

--- a/client/src/left_nav/HoldAlert.tsx
+++ b/client/src/left_nav/HoldAlert.tsx
@@ -4,7 +4,7 @@ import { Alert } from "@mui/material";
 export default function HoldAlert() {
   return (
     <Alert severity="error" sx={{ my: 2, borderRadius: 0 }}>
-      An hold has been placed on your account. You won't be able to create
+      A hold has been placed on your account. You won't be able to create
       reservations, use machines, or purchase materials.
       <br />
       <br />

--- a/client/src/left_nav/HoldAlert.tsx
+++ b/client/src/left_nav/HoldAlert.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Alert } from "@mui/lab";
+import { Alert } from "@mui/material";
 
 export default function HoldAlert() {
   return (
-    <Alert severity="error" sx={{ mb: 2, borderRadius: 0 }}>
+    <Alert severity="error" sx={{ my: 2, borderRadius: 0 }}>
       An hold has been placed on your account. You won't be able to create
       reservations, use machines, or purchase materials.
       <br />

--- a/client/src/left_nav/LeftNav.tsx
+++ b/client/src/left_nav/LeftNav.tsx
@@ -20,6 +20,7 @@ import { useCurrentUser } from "../common/CurrentUserProvider";
 import Privilege from "../types/Privilege";
 import { Outlet } from "react-router-dom";
 import { Box } from "@mui/material";
+import HoldAlert from "./HoldAlert";
 
 const StyledLogo = styled.img`
   margin: 20px 12px 12px 12px;
@@ -57,11 +58,7 @@ export default function LeftNav() {
           </Typography>
         </Stack>
 
-        {/*<Stack spacing={1} my={2}>*/}
-        {/*  <MonitorAlert />*/}
-        {/*  <CardReader />*/}
-        {/*  <HoldAlert />*/}
-        {/*</Stack>*/}
+        {currentUser.hasHold && <HoldAlert />}
 
         <List component="nav">
           {!isMaker && <Divider textAlign="left">MAKER</Divider>}

--- a/client/src/left_nav/LeftNav.tsx
+++ b/client/src/left_nav/LeftNav.tsx
@@ -58,7 +58,7 @@ export default function LeftNav() {
           </Typography>
         </Stack>
 
-        {currentUser.hasHold && <HoldAlert />}
+        {currentUser.hasHolds && <HoldAlert />}
 
         <List component="nav">
           {!isMaker && <Divider textAlign="left">MAKER</Divider>}

--- a/client/src/pages/admin/users/HoldCard.tsx
+++ b/client/src/pages/admin/users/HoldCard.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Card, CardActions, Stack, Typography } from "@mui/material";
+import { GET_USER, Hold } from "./UserModal";
+import { format, parseISO } from "date-fns";
+import { gql, useMutation } from "@apollo/client";
+import { LoadingButton } from "@mui/lab";
+
+const REMOVE_HOLD = gql`
+  mutation RemoveHold($holdID: ID!) {
+    removeHold(holdID: $holdID) {
+      id
+    }
+  }
+`;
+
+interface HoldCardProps {
+  hold: Hold;
+  userID: string;
+}
+
+export default function HoldCard({ hold, userID }: HoldCardProps) {
+  const [removeHold, result] = useMutation(REMOVE_HOLD, {
+    variables: { holdID: hold.id },
+    refetchQueries: [{ query: GET_USER, variables: { id: userID } }],
+  });
+
+  const removed = hold.removeDate && hold.remover;
+
+  return (
+    <Card
+      sx={{
+        backgroundColor: removed ? "grey.100" : "#fff8f8",
+        border: `1px solid ${removed ? "grey" : "red"}`,
+      }}
+    >
+      <Typography variant="body1" sx={{ fontWeight: 500, mt: 2, mx: 2 }}>
+        {hold.description}
+      </Typography>
+      <CardActions sx={{ px: 2 }}>
+        <Stack sx={{ flex: 1, color: "#595959" }}>
+          <Typography variant="body2">
+            Placed by {`${hold.creator.firstName} ${hold.creator.lastName}`} on{" "}
+            {format(parseISO(hold.createDate), "M/d/yy h:mmaaa")}
+          </Typography>
+
+          {hold.remover && hold.removeDate && (
+            <Typography variant="body2" sx={{ mb: 0.5 }}>
+              Removed by {`${hold.remover.firstName} ${hold.remover.lastName}`}{" "}
+              on {format(parseISO(hold.removeDate), "M/d/yy h:mmaaa")}
+            </Typography>
+          )}
+        </Stack>
+
+        {!removed && (
+          <LoadingButton
+            size="small"
+            color="error"
+            loading={result.loading}
+            onClick={() => removeHold()}
+          >
+            Remove hold
+          </LoadingButton>
+        )}
+      </CardActions>
+    </Card>
+  );
+}

--- a/client/src/test/LeftNav.test.tsx
+++ b/client/src/test/LeftNav.test.tsx
@@ -62,3 +62,20 @@ test("render properly for makers", async () => {
   expect(screen.queryByRole("link", { name: "People" })).toBeNull();
   expect(screen.queryByRole("link", { name: "History" })).toBeNull();
 });
+
+test("show hold alert when outstanding hold", async () => {
+  editCurrentUser({ holds: [{ removeDate: null }] });
+  renderApp();
+
+  await screen.findByText(/A hold has been placed on your account./);
+});
+
+test("don't show hold alert for removed holds", async () => {
+  editCurrentUser({ holds: [{ removeDate: "2022-03-30 22:24:15.944078+00" }] });
+  renderApp();
+
+  await screen.findByText("John Smith");
+  expect(
+    screen.queryByText(/A hold has been placed on your account./)
+  ).toBeNull();
+});

--- a/client/src/test/TestUtils.tsx
+++ b/client/src/test/TestUtils.tsx
@@ -26,6 +26,7 @@ export function resetMocks() {
             email: "jxs1234@rit.edu",
             privilege: Privilege.ADMIN,
             setupComplete: true,
+            holds: [],
           },
         },
       },

--- a/server/src/EntityNotFound.ts
+++ b/server/src/EntityNotFound.ts
@@ -1,0 +1,7 @@
+import { ApolloError } from "apollo-server-errors";
+
+export class EntityNotFound extends ApolloError {
+  constructor(message: string) {
+    super(message, "ENTITY_NOT_FOUND");
+  }
+}

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -10,8 +10,8 @@ import {
   createUser,
   getUserByRitUsername,
 } from "./repositories/Users/UserRepository";
-import { createLog } from "./repositories/AuditLogs/AuditLogRepository";
-import { User as AppUser } from "./schemas/usersSchema"
+import { User as AppUser } from "./schemas/usersSchema";
+import { getHoldsByUser } from "./repositories/Holds/HoldsRepository";
 
 interface RitSsoUser {
   firstName: string;
@@ -144,7 +144,14 @@ export function setupAuth(app: express.Application) {
   });
 
   passport.deserializeUser(async (username: string, done) => {
-    const user = await getUserByRitUsername(username);  
+    const user = await getUserByRitUsername(username);
+
+    // Populate user.hasHolds
+    const holds = await getHoldsByUser(user.id);
+    user.hasHolds = holds.some(
+      (hold: { removeDate: string }) => !hold.removeDate
+    );
+
     /* @ts-ignore */
     done(null, user);
   });

--- a/server/src/context.ts
+++ b/server/src/context.ts
@@ -18,7 +18,9 @@ const ifAllowed =
     }
 
     const user = expressUser as User;
+
     const sufficientPrivilege = allowedPrivileges.includes(user.privilege);
+    console.log(user);
 
     if (!sufficientPrivilege) {
       throw new ForbiddenError("Insufficient privilege");

--- a/server/src/context.ts
+++ b/server/src/context.ts
@@ -20,13 +20,13 @@ const ifAllowed =
     const user = expressUser as User;
 
     const sufficientPrivilege = allowedPrivileges.includes(user.privilege);
-    console.log(user);
-
     if (!sufficientPrivilege) {
       throw new ForbiddenError("Insufficient privilege");
     }
 
-    // TODO: if (userHasHold) throw new ForbiddenError("Account on hold");
+    if (user.hasHolds) {
+      throw new ForbiddenError("User has outstanding account holds");
+    }
 
     return callback(user);
   };

--- a/server/src/db/migrations/20220126063347_holds_table.ts
+++ b/server/src/db/migrations/20220126063347_holds_table.ts
@@ -1,26 +1,25 @@
 import { Knex } from "knex";
 
-
 export async function up(knex: Knex): Promise<void> {
-    return knex.schema.hasTable('Holds').then(function(exists) {
-        if (!exists) {
-            return knex.schema.createTable('Holds', function(t) {
-                t.increments('id');
-                t.enu('type', ['INCOMPLETE_TRAINING', 'SAFETY_VIOLATION', 'BALANCE_DUE']);
-                t.text('description');
-                t.timestamp('created_at').defaultTo(knex.fn.now());
-                t.timestamp('removed_at');
-                t.integer('user_id').references('id').inTable('Users');
-              });
-        }
-    });
+  return knex.schema.hasTable("Holds").then(function (exists) {
+    if (!exists) {
+      return knex.schema.createTable("Holds", function (t) {
+        t.increments("id");
+        t.integer("creatorID").references("id").inTable("Users");
+        t.integer("removerID").references("id").inTable("Users");
+        t.integer("userID").references("id").inTable("Users");
+        t.text("description");
+        t.timestamp("createDate").defaultTo(knex.fn.now());
+        t.timestamp("removeDate");
+      });
+    }
+  });
 }
 
-
 export async function down(knex: Knex): Promise<void> {
-    return knex.schema.hasTable('Holds').then(function(exists) {
-        if (exists) {
-          return knex.schema.dropTable('Holds');
-        }
-      });
+  return knex.schema.hasTable("Holds").then(function (exists) {
+    if (exists) {
+      return knex.schema.dropTable("Holds");
+    }
+  });
 }

--- a/server/src/repositories/Holds/HoldsRepository.ts
+++ b/server/src/repositories/Holds/HoldsRepository.ts
@@ -1,0 +1,43 @@
+import { knex } from "../../db";
+import { Hold } from "../../schemas/holdsSchema";
+import { EntityNotFound } from "../../EntityNotFound";
+
+export async function getHold(id: number): Promise<Hold> {
+  const hold = await knex("Holds").first().where({ id });
+
+  if (!hold) throw new EntityNotFound(`Hold #${id} not found`);
+
+  return hold;
+}
+
+export async function createHold(
+  creatorID: number,
+  userID: number,
+  description: string
+): Promise<Hold> {
+  const [holdID] = await knex("Holds").insert(
+    {
+      creatorID,
+      userID,
+      description: description,
+    },
+    "id"
+  );
+
+  return getHold(holdID);
+}
+
+export async function removeHold(holdID: number, removerID: number) {
+  await knex("Holds")
+    .update({
+      removerID,
+      removeDate: knex.fn.now(),
+    })
+    .where({ id: holdID });
+
+  return getHold(holdID);
+}
+
+export async function getUsersHolds(userID: number) {
+  return knex("Holds").select().where({ userID }).orderBy("createDate", "DESC");
+}

--- a/server/src/repositories/Holds/HoldsRepository.ts
+++ b/server/src/repositories/Holds/HoldsRepository.ts
@@ -38,6 +38,6 @@ export async function removeHold(holdID: number, removerID: number) {
   return getHold(holdID);
 }
 
-export async function getUsersHolds(userID: number) {
+export async function getHoldsByUser(userID: number) {
   return knex("Holds").select().where({ userID }).orderBy("createDate", "DESC");
 }

--- a/server/src/repositories/Users/UserRepository.ts
+++ b/server/src/repositories/Users/UserRepository.ts
@@ -7,22 +7,20 @@ import {
 import { createLog } from "../AuditLogs/AuditLogRepository";
 import assert from "assert";
 import { getUsersFullName } from "../../resolvers/usersResolver";
-
-/*
-todo
-get users by room,
-search/get users by name
-get users by module
-*/
+import { EntityNotFound } from "../../EntityNotFound";
 
 export async function getUsers(): Promise<User[]> {
   const knexResult = await knex("Users").select();
   return usersToDomain(knexResult);
 }
 
-export async function getUserByID(userID: number): Promise<User | null> {
+export async function getUserByID(userID: number): Promise<User> {
   const knexResult = await knex("Users").first().where("id", userID);
-  return singleUserToDomain(knexResult);
+  const user = singleUserToDomain(knexResult);
+
+  if (!user) throw new EntityNotFound(`User #${userID} not found`);
+
+  return user;
 }
 
 export async function getUserByRitUsername(
@@ -97,15 +95,7 @@ export function removeTrainingFromUser(
   throw new Error("Method not implemented.");
 }
 
-export function addHoldToUser(userID: number, holdID: number) {
-  throw new Error("Method not implemented.");
-}
-
-export function removeHoldFromUser(userID: number, holdID: number) {
-  throw new Error("Method not implemented.");
-}
-
-export async function archiveUser(userID: number){
-  await knex("Users").where({ id: userID}).update({isArchived: true})
-  return await getUserByID(userID)
+export async function archiveUser(userID: number) {
+  await knex("Users").where({ id: userID }).update({ isArchived: true });
+  return await getUserByID(userID);
 }

--- a/server/src/repositories/Users/UserRepository.ts
+++ b/server/src/repositories/Users/UserRepository.ts
@@ -23,13 +23,17 @@ export async function getUserByID(userID: number): Promise<User> {
   return user;
 }
 
-export async function getUserByRitUsername(
-  ritUsername: string
-): Promise<User | null> {
+export async function getUserByRitUsername(ritUsername: string): Promise<User> {
   const knexResult = await knex("Users")
     .first()
     .where("ritUsername", ritUsername);
-  return singleUserToDomain(knexResult);
+
+  const user = singleUserToDomain(knexResult);
+
+  if (!user)
+    throw new EntityNotFound(`User with RIT username ${ritUsername} not found`);
+
+  return user;
 }
 
 export async function getUserByUniversityID(

--- a/server/src/resolvers/holdsResolver.ts
+++ b/server/src/resolvers/holdsResolver.ts
@@ -1,0 +1,66 @@
+import { ApolloContext } from "../context";
+import { Privilege, User } from "../schemas/usersSchema";
+import * as HoldsRepo from "../repositories/Holds/HoldsRepository";
+import * as UsersRepo from "../repositories/Users/UserRepository";
+import { Hold } from "../schemas/holdsSchema";
+import { createLog } from "../repositories/AuditLogs/AuditLogRepository";
+import { getUsersFullName } from "./usersResolver";
+import { EntityNotFound } from "../EntityNotFound";
+
+const HoldsResolvers = {
+  User: {
+    holds: async (parent: User) => HoldsRepo.getUsersHolds(parent.id),
+  },
+
+  Hold: {
+    creator: async (parent: Hold, _args: any, { ifAllowed }: ApolloContext) =>
+      ifAllowed([Privilege.LABBIE, Privilege.ADMIN], async () => {
+        return UsersRepo.getUserByID(parent.creatorID);
+      }),
+
+    remover: async (parent: Hold, _args: any, { ifAllowed }: ApolloContext) =>
+      ifAllowed(
+        [Privilege.LABBIE, Privilege.ADMIN],
+        async () => parent.removerID && UsersRepo.getUserByID(parent.removerID)
+      ),
+  },
+
+  Mutation: {
+    createHold: async (
+      _parent: any,
+      args: { userID: number; description: string },
+      { ifAllowed }: ApolloContext
+    ) =>
+      ifAllowed([Privilege.LABBIE, Privilege.ADMIN], async (user) => {
+        const userWithHold = await UsersRepo.getUserByID(args.userID);
+
+        await createLog(
+          "{user} placed a hold on {user}'s account.",
+          { id: user.id, label: getUsersFullName(user) },
+          { id: args.userID, label: getUsersFullName(userWithHold) }
+        );
+
+        return HoldsRepo.createHold(user.id, args.userID, args.description);
+      }),
+
+    removeHold: async (
+      _parent: any,
+      args: { holdID: number },
+      { ifAllowed }: ApolloContext
+    ) =>
+      ifAllowed([Privilege.LABBIE, Privilege.ADMIN], async (user) => {
+        const hold = await HoldsRepo.getHold(args.holdID);
+        const userWithHold = await UsersRepo.getUserByID(hold.userID);
+
+        await createLog(
+          "{user} removed a hold on {user}'s account.",
+          { id: user.id, label: getUsersFullName(user) },
+          { id: userWithHold.id, label: getUsersFullName(userWithHold) }
+        );
+
+        return HoldsRepo.removeHold(args.holdID, user.id);
+      }),
+  },
+};
+
+export default HoldsResolvers;

--- a/server/src/resolvers/holdsResolver.ts
+++ b/server/src/resolvers/holdsResolver.ts
@@ -9,7 +9,7 @@ import { EntityNotFound } from "../EntityNotFound";
 
 const HoldsResolvers = {
   User: {
-    holds: async (parent: User) => HoldsRepo.getUsersHolds(parent.id),
+    holds: async (parent: User) => HoldsRepo.getHoldsByUser(parent.id),
   },
 
   Hold: {

--- a/server/src/resolvers/usersResolver.ts
+++ b/server/src/resolvers/usersResolver.ts
@@ -13,7 +13,6 @@ export function hashUniversityID(universityID: string) {
   return createHash("sha256").update(universityID).digest("hex");
 }
 
-//TODO: Update all "args" parameters upon implementation
 const UsersResolvers = {
   Query: {
     users: async () => {
@@ -75,14 +74,6 @@ const UsersResolvers = {
 
     removeTraining: async (_: any, args: any, context: any) => {
       await UserRepo.removeTrainingFromUser(args.userID, args.trainingModuleID);
-    },
-
-    addHold: async (_: any, args: any, context: any) => {
-      await UserRepo.addHoldToUser(args.userID, args.holdID);
-    },
-
-    removeHold: async (_: any, args: any, context: any) => {
-      await UserRepo.removeHoldFromUser(args.userID, args.holdID);
     },
 
     archiveUser: async (

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -15,6 +15,7 @@ import roomsResolver from "./resolvers/roomsResolver";
 import EquipmentResolvers from "./resolvers/equipmentResolver";
 import usersResolver from "./resolvers/usersResolver";
 import auditLogsResolver from "./resolvers/auditLogsResolver";
+import holdsResolver from "./resolvers/holdsResolver";
 
 // for custom scalars such as Date
 const resolveFunctions = {
@@ -40,6 +41,7 @@ export const schema = makeExecutableSchema({
     storefrontResolvers,
     roomsResolver,
     usersResolver,
+    holdsResolver,
     auditLogsResolver,
   ]),
 });

--- a/server/src/schemas/holdsSchema.ts
+++ b/server/src/schemas/holdsSchema.ts
@@ -1,24 +1,24 @@
 import { gql } from "apollo-server-express";
-import { User } from "./usersSchema";
 
 export interface Hold {
   id: number;
-  user: User;
+  creatorID: number;
+  removerID?: number;
+  userID: number;
   description: string;
-  active: boolean;
-}
-
-export interface HoldInput {
-  user: number;
-  description: string;
+  createDate: Date;
+  removeDate?: Date;
 }
 
 export const HoldsTypeDefs = gql`
   type Hold {
     id: ID!
+    creator: User!
+    remover: User
     user: User!
-    description: String
-    active: Boolean
+    description: String!
+    createDate: DateTime!
+    removeDate: DateTime
   }
 
   input HoldInput {
@@ -26,7 +26,8 @@ export const HoldsTypeDefs = gql`
     description: String
   }
 
-  type Query {
-    holds: [Hold]
+  extend type Mutation {
+    createHold(userID: ID!, description: String!): Hold
+    removeHold(holdID: ID!): Hold
   }
 `;

--- a/server/src/schemas/usersSchema.ts
+++ b/server/src/schemas/usersSchema.ts
@@ -26,6 +26,7 @@ export interface User {
   pronouns: string;
   setupComplete: boolean;
   isArchived: boolean;
+  hasHolds?: boolean;
 }
 
 export const UsersTypeDefs = gql`

--- a/server/src/schemas/usersSchema.ts
+++ b/server/src/schemas/usersSchema.ts
@@ -28,16 +28,6 @@ export interface User {
   isArchived: boolean;
 }
 
-export interface StudentUserInput {
-  universityID: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  expectedGraduation: string;
-  college: string;
-  major: string;
-}
-
 export const UsersTypeDefs = gql`
   enum Privilege {
     MAKER
@@ -111,8 +101,12 @@ export const UsersTypeDefs = gql`
   }
 
   extend type Mutation {
-
-    createUser(firstName: String, lastName: String, ritUsername: String, email: String): User
+    createUser(
+      firstName: String
+      lastName: String
+      ritUsername: String
+      email: String
+    ): User
 
     updateStudentProfile(
       userID: ID!
@@ -126,9 +120,6 @@ export const UsersTypeDefs = gql`
 
     addTraining(userID: ID!, moduleID: ID!): User
     removeTraining(userID: ID!, moduleID: ID!): User
-
-    addHold(userID: ID!, hold: HoldInput): User
-    removeHold(userID: ID!, hold: HoldInput): User
 
     archiveUser(userID: ID!): User
   }


### PR DESCRIPTION
- Labbies and admins can create, view and remove holds on users from the users page
- Creating & removing holds creates an audit log
- When you have an outstanding hold, a notification appears in the nav bar
- `ifAllowed()` ensures that the user has no outstanding holds before invoking the callback