### PR TITLE
removed correct fields from modules for makers

### DIFF
--- a/server/src/context.ts
+++ b/server/src/context.ts
@@ -13,6 +13,7 @@ export interface ApolloContext {
     allowedPrivileges: Privilege[],
     callback: (user: CurrentUser) => any
   ) => any;
+  ifAuthenticated: (callback: (user: CurrentUser) => any) => any;
 }
 
 const ifAllowed =
@@ -36,10 +37,24 @@ const ifAllowed =
     return callback(user);
   };
 
+// only checks if user is authenticated (for actions where holds or privileges do not matter)
+const ifAuthenticated =
+  (expressUser: Express.User | undefined) =>
+  (callback: (user: CurrentUser) => any) => {
+    if (!expressUser) {
+      throw new AuthenticationError("Unauthenticated");
+    }
+
+    const user = expressUser as CurrentUser;
+
+    return callback(user);
+  };
+
 const context = ({ req }: { req: any }) => ({
   user: req.user,
   logout: () => req.logout(),
   ifAllowed: ifAllowed(req.user),
+  ifAuthenticated: ifAuthenticated(req.user),
 });
 
 export default context;

--- a/server/src/db/tables.ts
+++ b/server/src/db/tables.ts
@@ -105,7 +105,7 @@ export interface TrainingModuleItem {
 export interface ModuleItemOption {
   id: string;
   text: string;
-  correct: boolean;
+  correct?: boolean;
 }
 
 export interface UserRow {

--- a/server/src/resolvers/trainingResolver.ts
+++ b/server/src/resolvers/trainingResolver.ts
@@ -6,6 +6,17 @@ import { createLog } from "../repositories/AuditLogs/AuditLogRepository";
 import { getUsersFullName } from "./usersResolver";
 import { addTrainingModuleAttemptToUser } from "../repositories/Users/UserRepository";
 import { MODULE_PASSING_THRESHOLD } from "../constants";
+import { TrainingModuleItem } from "../db/tables";
+
+const removeAnswersFromQuiz = (quiz: TrainingModuleItem[]) => {
+  for (let item of quiz) {
+    if (item.options) {
+      for (let option of item.options) {
+        delete option.correct;
+      }
+    }
+  }
+};
 
 const TrainingResolvers = {
   Query: {
@@ -18,14 +29,7 @@ const TrainingResolvers = {
         let modules = await ModuleRepo.getModules();
 
         if (user.privilege === "MAKER")
-          for (let module of modules)
-            for (let item of module.quiz) {
-              if (item.options) {
-                for (let option of item.options) {
-                  delete option.correct;
-                }
-              }
-            }
+          for (let module of modules) removeAnswersFromQuiz(module.quiz);
 
         return modules;
       }),
@@ -38,14 +42,7 @@ const TrainingResolvers = {
       ifAuthenticated(async (user) => {
         let module = await ModuleRepo.getModuleByID(args.id);
 
-        if (user.privilege === "MAKER")
-          for (let item of module.quiz) {
-            if (item.options) {
-              for (let option of item.options) {
-                delete option.correct;
-              }
-            }
-          }
+        if (user.privilege === "MAKER") removeAnswersFromQuiz(module.quiz);
 
         return module;
       }),


### PR DESCRIPTION
The `module` and `modules` resolvers now will removed the `correct` field from the json quiz object if the user's privilege is `MAKER`. These resolvers now require the user to be authenticated. I could update the `IsAuthenticated` function to simply return a boolean, and return the stripped quiz view to unauthenticated users as well if you think that's worth it