### PR TITLE
Fixed handling of canceling the placing of a hold

### DIFF
--- a/client/src/pages/admin/users/UserModal.tsx
+++ b/client/src/pages/admin/users/UserModal.tsx
@@ -100,8 +100,11 @@ export default function UserModal({ selectedUserID, onClose }: UserModalProps) {
 
   const handlePlaceHoldClicked = () => {
     const description = window.prompt("Enter hold description:");
-    if (!description) {
+    if (description == "") {
       window.alert("Description required.");
+      return;
+    }
+    else if (!description) {
       return;
     }
 


### PR DESCRIPTION
Before:
When an admin places a hold, a prompt appears to describe the reason for the hold. If the admin were to press cancel, a message would appear saying the description cannot be empty. Same handling for submitting an empty description.

Now: 
If the admin presses cancel, the window will close regardless of description contents. When admin presses submit on an empty description, it shows message that description cannot be empty and does not submit the hold. 