### PR TITLE
Add support for a dev database

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,4 @@
+DB_SCHEMA=dev
 DATABASE_URL=postgresql://makerspace:makerspace_secret@localhost:5433/makerspace
 SESSION_SECRET=super_secret
 REACT_APP_ORIGIN=http://localhost:3001

--- a/server/src/db/index.ts
+++ b/server/src/db/index.ts
@@ -6,9 +6,6 @@ const require = createRequire(import.meta.url);
 const connection =
   config[process.env.NODE_ENV || "development"];
 
-export function newInstance() {
-  return config[process.env.NODE_ENV || "development"];
-}
 
 const knexInstance = knex(connection);
 

--- a/server/src/db/knexFile.ts
+++ b/server/src/db/knexFile.ts
@@ -18,8 +18,9 @@ const config: any = { //remove ': any' if using --esm
   development: {
     client: "pg",
     connection: {
-      connectionString: process.env.DATABASE_URL,
+      connectionString: process.env.DATABASE_URL + (process.env.DB_SCHEMA ? ('?currentSchema=' + process.env.DB_SCHEMA) : ""),
       ssl: false,
+
     },
     pool: {
       min: 2,
@@ -32,6 +33,7 @@ const config: any = { //remove ': any' if using --esm
         });
       }
     },
+    searchPath: process.env.DB_SCHEMA || "public",
     migrations: {
       tableName: "knex_migrations",
       directory: "migrations",
@@ -42,7 +44,7 @@ const config: any = { //remove ': any' if using --esm
   staging: {
     client: "pg",
     connection: {
-      connectionString: process.env.DATABASE_URL,
+      connectionString: process.env.DATABASE_URL + (process.env.DB_SCHEMA ? ('?currentSchema=' + process.env.DB_SCHEMA) : ""),
       ssl: {
         rejectUnauthorized: false,
         sslmode: 'require',
@@ -52,6 +54,7 @@ const config: any = { //remove ': any' if using --esm
       min: 2,
       max: 10,
     },
+    searchPath: process.env.DB_SCHEMA || "public",
     migrations: {
       tableName: "knex_migrations",
       directory: "migrations",

--- a/server/src/repositories/DevDatabaseSync.ts
+++ b/server/src/repositories/DevDatabaseSync.ts
@@ -1,0 +1,44 @@
+import { knex } from "../db/index.js";
+
+const script: string = `
+CREATE OR REPLACE FUNCTION clone_schema(source_schema text, dest_schema text) RETURNS void AS
+$BODY$
+DECLARE 
+  objeto text;
+  buffer text;
+  src_buffer text;
+BEGIN
+	RAISE NOTICE 'Copying Prod schema to dev';
+	EXECUTE 'DROP SCHEMA IF EXISTS ' || dest_schema || ' cascade';
+    EXECUTE 'CREATE SCHEMA if not exists ' || dest_schema ;
+
+    FOR objeto IN
+        SELECT table_name FROM information_schema.tables WHERE table_schema = source_schema and table_type = 'BASE TABLE'
+    LOOP        
+        buffer := dest_schema || '."' || objeto || '"';
+		src_buffer := source_schema || '."' || objeto ||'"';
+
+    	EXECUTE 'CREATE TABLE ' || buffer || ' (LIKE ' || src_buffer || ' INCLUDING all)';
+        EXECUTE 'INSERT INTO ' || buffer || '(SELECT * FROM ' || src_buffer || ')';
+    END LOOP;
+
+END;
+$BODY$
+LANGUAGE plpgsql VOLATILE;
+
+SELECT clone_schema('public','dev');
+`
+
+
+export async function copyProdDBToDev() {
+    if (process.env.RUN_DATABASE_SYNC_TO_DEV == null || process.env.RUN_DATABASE_SYNC_TO_DEV !== 'true') {
+        console.log(`Not syncing DB: RUN_DATABASE_SYNC_TO_DEV=${process.env.RUN_DATABASE_SYNC_TO_DEV}`)
+        return;
+    }
+    console.log("Copying production data to dev");
+    try {
+        await knex.raw(script);
+    } catch (e) {
+        console.error(`Failed to sync prod DB to dev: ${e}`);
+    }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -31,6 +31,7 @@ import { getHoursByZone, WeekDays } from "./repositories/Zones/ZoneHoursReposito
 import { createEquipmentSession, setLatestEquipmentSessionLength } from "./repositories/Equipment/EquipmentSessionsRepository.js";
 import { setDataPointValue } from "./repositories/DataPoints/DataPointsRepository.js";
 import { ReaderRow } from "./db/tables.js";
+import { copyProdDBToDev } from "./repositories/DevDatabaseSync.js";
 const require = createRequire(import.meta.url);
 
 const allowed_origins = [process.env.REACT_APP_ORIGIN, "https://studio.apollographql.com", "https://make.rit.edu", "https://shibboleth.main.ad.rit.edu"];
@@ -713,6 +714,8 @@ async function startServer() {
     console.log('Wiping daily records...');
     if (API_DEBUG_LOGGING) await createLog('It is now 4:00am. Daily Temp Records have been wiped.', "server")
     setDataPointValue(1, 0);
+
+    copyProdDBToDev();
   });
 
 


### PR DESCRIPTION
Rather than testing on production, we can now test a little bit away from production with 'production data' from the all days before now.

Two Environment variables were added

## RUN_DATABASE_SYNC_TO_DEV
if 'true', when its 4 am, sync the production database to dev

## DB_SCHEMA=dev
This selects which schema to use. if missing, use the default (public)