### PR TITLE
Remove lab training alert temporarily

### DIFF
--- a/client/src/top_nav/TopNav.tsx
+++ b/client/src/top_nav/TopNav.tsx
@@ -74,7 +74,7 @@ export default function TopNav() {
 //          All Makerspace users must complete the <a href="https://www.youtube.com/watch?v=XfELJU1mRMg">Shop Safety training course</a> before using any equipment.
 //        </Alert>
 //        : null
-//    }
+    }
     </Stack>
 
   const navlinks = [


### PR DESCRIPTION
Commented out the lab training alert and added a note about re-enabling it when the new training link is available.