### PR TITLE
Serve root cert to devices with the ability to verify that the server knows the device

### DIFF
--- a/client/src/pages/makerspace_page/ExpandableHeader.tsx
+++ b/client/src/pages/makerspace_page/ExpandableHeader.tsx
@@ -5,7 +5,7 @@ import { isManagerFor } from "../../common/PrivilegeUtils";
 import EditIcon from "@mui/icons-material/Edit";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import { FullMakerspace } from "../../queries/makerspaceQueries";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useCurrentUser } from "../../common/CurrentUserProvider";
 import MakerspaceHours from "../../types/MakerspaceHours";
 import MakerspaceHoursSection from "./MakerspaceHours";
@@ -127,10 +127,12 @@ export default function ExpandableHeader({ makerspace, makerspaceTrainings }: Ex
   const navigate = useNavigate();
   const isMobile = useIsMobile();
 
-  const [expanded, setExpanded] = useState<boolean>(user.visitor);
+  const [searchParams, setSearchParams] = useSearchParams()
+  const startOpen = searchParams.get("o") == "1"
+  const [expanded, setExpanded] = useState<boolean>(user.visitor || startOpen);
 
   return (
-    <Accordion expanded={expanded} sx={{ border: "none" }} elevation={0} onChange={() => setExpanded(!expanded)}>
+    <Accordion expanded={expanded} sx={{ border: "none" }} elevation={0} onChange={() => {setExpanded(!expanded); setSearchParams({"o":(!expanded)  ? "1" : "0"})}}>
       <AccordionSummary>
         {TitleRow(
           navigate,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -43,10 +43,10 @@ import fs from "node:fs";
 import { ViteDevServer } from "vite";
 import { SiteSettings } from "./database/models/site_settings/SiteSettings.js";
 import * as ThemeRepo from "./database/repositories/SiteSettings/ThemesRepository.js";
+import { createHash } from 'node:crypto';
 
 const require = createRequire(import.meta.url);
 
-const allowed_origins = [process.env.VITE_ORIGIN, "https://studio.apollographql.com", "https://make.rit.edu", "https://shibboleth.main.ad.rit.edu"];
 const SECURE_ORIGIN = (process.env.VITE_ORIGIN ?? "");
 const __dirname = import.meta.dirname;
 
@@ -249,12 +249,32 @@ async function startServer() {
   });
   app.use("/api/files/", express.static(path.join(__dirname, '../../client/shlug-files/')));
 
-  app.get("/api/files/certCA", async function (req, res) {
+  app.get("/api/rootCA", async function (req, res) {
+    const SNHeader = 'shlug-sn';
+    if (!req.headers[SNHeader]) {
+      return res.status(401).send();
+    }
+    const SN = req.headers[SNHeader];
+    if (typeof SN !== "string") {
+      return res.status(401).send();
+    }
+
+    const device = await getDeviceBySN(SN);
+    if (device == null) {
+      return res.status(404).send();
+    }
+
     const certca = (await getReaderCertCA())?.value;
     if (certca == null) {
       return res.status(404).send();
     }
-    return res.send(certca);
+    const textForSha = `${device.SN}:${await device.generateKey()}:${certca}`
+    const sha = createHash('sha256').update(textForSha).digest('hex')
+    const result = {
+      cert: certca,
+      sha: sha,
+    } 
+    return res.json(result);
   })
 
   app.get('/api/files/ota/:tagname', async function (req, res) {
@@ -557,7 +577,8 @@ async function startServer() {
       }
 
       const certString = await response.text();
-      setReaderCertCA(certString);
+      // normalize \r\n to \n
+      setReaderCertCA(certString.replace(/\r/g,""));
     } catch (error) {
       console.error(`Failed to update root cert: ${error}`)
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -16,7 +16,7 @@ import path from "path";
 import * as schedule from "node-schedule";
 import { getUserByCardTagID, getUsersFullName } from "./database/repositories/Users/UserRepository.js";
 import { createUnassocaitedAuditLog } from "./database/repositories/AuditLogs/AuditLogRepository.js";
-import { getReaderCertCA } from "./database/repositories/Readers/ReaderRepository.js";
+import { getReaderCertCA, setReaderCertCA } from "./database/repositories/Readers/ReaderRepository.js";
 import morgan from "morgan"; //Log provider
 import { createRequire } from "module";
 import { setDataPointValue } from "./database/repositories/DataPoints/DataPointsRepository.js";
@@ -542,6 +542,26 @@ async function startServer() {
     createUnassocaitedAuditLog(`Trainings: Sent ${numNotified} expiry notices, and purged ${numPurged} expired trainings.`, "server")
 
   }
+  async function updateRootCert() {
+    try {
+      const url = process.env.READER_CERT_URL;
+      if (url == undefined || url == "") {
+        console.error("Can not update root cert. No download URL provided");
+        return
+      }
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        console.error(`Could not download new root cert. HTTP error: ${response.status}`)
+        return;
+      }
+
+      const certString = await response.text();
+      setReaderCertCA(certString);
+    } catch (error) {
+      console.error(`Failed to update root cert: ${error}`)
+    }
+  }
   /**
    Cron Format:
     *    *    *    *    *    *
@@ -573,6 +593,9 @@ async function startServer() {
 
     // Advance any time-based maintennace tickets from UPCOMING -> TODO
     await advanceTimeTickets();
+
+    // Get a new root certificate for readers
+    await updateRootCert();
 
     // Command all cores to restart for the periodic restart
     await scheduledRestartAllCores();


### PR DESCRIPTION
Closes #1316

Embedded devices can query this endpoint with the standard shlug-sn header and NOT with the key header. In this way, it will not reveal its secret when trying to get its new cert. The servert returns its copy of the root cert as well as a digest created from the sn, key, and cert. In this way the device can verify the server and trust the given cert through the pre shared secret key. 
The digest is created by taking the sha256sum of `serial_number:key:cert`
Each morning at 4am the server downloads a new copy of the the root cert to give to devices. 

Uses 
`READER_CERT_URL='https://letsencrypt.org/certs/isrg-root-x1-cross-signed.pem'`
